### PR TITLE
fixing SSL_read arg size in client

### DIFF
--- a/client.c
+++ b/client.c
@@ -69,7 +69,7 @@ int main(int argc, const char **argv)
 			ASSERT_SSL(sizeof(buf) == err);
 		}
 		if (FD_ISSET(sock, &rfds)) {
-			err = SSL_read(ssl, buf, err);
+			err = SSL_read(ssl, buf, sizeof(buf));
 			if (0 == err) break;
 			ASSERT_SSL(sizeof(buf) == err);
 			err = write(STDOUT_FILENO, buf, sizeof(buf));


### PR DESCRIPTION
I think the size argument for SSL_read is wrong, the err value is inherited from SSL_write call if it happens, it should be sizeof(buf) or PACKET_SIZE
